### PR TITLE
Fix file permissions of bin/os.ProductNews.pl

### DIFF
--- a/ProductNews.sopm
+++ b/ProductNews.sopm
@@ -23,7 +23,7 @@
         <File Permission="644" Location="Kernel/Output/HTML/Standard/ProductNewsSnippet.tt" />
         <File Permission="644" Location="Kernel/Output/HTML/Standard/ProductNewsSnippetLogin.tt"/>
         <File Permission="644" Location="Kernel/System/ProductNews.pm" />
-        <File Permission="644" Location="bin/ps.ProductNews.pl" />
+        <File Permission="755" Location="bin/ps.ProductNews.pl" />
         <File Permission="644" Location="doc/en/ProductNews.pod" />
         <File Permission="644" Location="var/cron/product_news.dist" />
         <File Permission="644" Location="var/httpd/htdocs/js/Core.UI.Dialog.DynamicContentDialog.js"/>


### PR DESCRIPTION
File was delivered as 644, but should be 755 in order to be executable.
