### PR TITLE
Added Hungarian translation and small fixes

### DIFF
--- a/Kernel/Config/Files/ProductNews.xml
+++ b/Kernel/Config/Files/ProductNews.xml
@@ -11,7 +11,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Loader::Customer::CommonJS###090-ProductX" Required="1" Valid="1">
-        <Description Translatable="1">List of JS files to always be loaded for the agent interface.</Description>
+        <Description Translatable="1">List of JS files to always be loaded for the customer interface.</Description>
         <Group>ProductNews</Group>
         <SubGroup>Core::Web</SubGroup>
         <Setting>
@@ -21,7 +21,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Loader::Agent::CommonCSS###090-ProductNewsX" Required="1" Valid="1">
-        <Description Translatable="1">List of CSS files to always be loaded for the customer interface.</Description>
+        <Description Translatable="1">List of CSS files to always be loaded for the agent interface.</Description>
         <Group>Framework</Group>
         <SubGroup>Core::Web</SubGroup>
         <Setting>
@@ -41,41 +41,38 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::Module###AgentProductNews" Required="0" Valid="1">
-        <Description Lang="en">Frontend module registration for the  agent interface.</Description>
-        <Description Lang="de">Frontendmodul-Registration für das  Agenten Interface.</Description>
+        <Description Translatable="1">Frontend module registration for the agent interface.</Description>
         <Group>ProductNews</Group>
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description> Product News</Description>
+                <Description Translatable="1">Product News</Description>
                 <NavBarName></NavBarName>
-                <Title> Product News</Title>
+                <Title Translatable="1">Product News</Title>
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="CustomerFrontend::Module###AgentProductNews" Required="0" Valid="1">
-        <Description Lang="en">Frontend module registration for the  agent interface.</Description>
-        <Description Lang="de">Frontendmodul-Registration für das  Agenten Interface.</Description>
+        <Description Translatable="1">Frontend module registration for the agent interface.</Description>
         <Group>ProductNews</Group>
         <SubGroup>Frontend::Customer::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description> Product News</Description>
+                <Description Translatable="1">Product News</Description>
                 <NavBarName></NavBarName>
-                <Title> Product News</Title>
+                <Title Translatable="1">Product News</Title>
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::Module###AgentProductNewsMarkRead" Required="0" Valid="1">
-        <Description Lang="en">Frontend module registration for the  agent interface.</Description>
-        <Description Lang="de">Frontendmodul-Registration für das  Agenten Interface.</Description>
+        <Description Translatable="1">Frontend module registration for the agent interface.</Description>
         <Group>ProductNews</Group>
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description> Product News</Description>
+                <Description Translatable="1">Product News</Description>
                 <NavBarName></NavBarName>
-                <Title> Product News</Title>
+                <Title Translatable="1">Product News</Title>
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>
@@ -86,7 +83,7 @@
         <Setting>
             <FrontendModuleReg>
                 <Group>admin</Group>
-                <Description>Create and manage news.</Description>
+                <Description Translatable="1">Create and manage news.</Description>
                 <Title>Product News</Title>
                 <NavBarName>Admin</NavBarName>
                 <NavBarModule>
@@ -106,8 +103,8 @@
         <Setting>
             <Hash>
                 <Item Key="Module">Kernel::Output::HTML::Dashboard::ProductNews</Item>
-                <Item Key="Title">Product News</Item>
-                <Item Key="Description">News!</Item>
+                <Item Key="Title" Translatable="1">Product News</Item>
+                <Item Key="Description" Translatable="1">News!</Item>
                 <Item Key="Block">ContentLarge</Item>
                 <Item Key="Group">users</Item>
                 <Item Key="Default">1</Item>
@@ -122,8 +119,8 @@
         <SubGroup>Core::ProductNews</SubGroup>
         <Setting>
             <Option SelectedID="1">
-                <Item Key="0">Disabled</Item>
-                <Item Key="1">Enabled</Item>
+                <Item Key="0" Translatable="1">Disabled</Item>
+                <Item Key="1" Translatable="1">Enabled</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -133,8 +130,8 @@
         <SubGroup>Core::ProductNews</SubGroup>
         <Setting>
             <Option SelectedID="0">
-                <Item Key="0">Disabled</Item>
-                <Item Key="1">Enabled</Item>
+                <Item Key="0" Translatable="1">Disabled</Item>
+                <Item Key="1" Translatable="1">Enabled</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -144,8 +141,8 @@
         <SubGroup>Core::ProductNews</SubGroup>
         <Setting>
             <Option SelectedID="1">
-                <Item Key="0">Disabled</Item>
-                <Item Key="1">Enabled</Item>
+                <Item Key="0" Translatable="1">Disabled</Item>
+                <Item Key="1" Translatable="1">Enabled</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -158,13 +155,13 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="ProductNews::GlobalMarkRead" Required="1" Valid="1">
-        <Description Translatable="1">If enabled, everybody kann set the message to "invalid" by clicking "mark as read".</Description>
+        <Description Translatable="1">If enabled, everybody can set the message to "invalid" by clicking "mark as read".</Description>
         <Group>ProductNews</Group>
         <SubGroup>Core::ProductNews</SubGroup>
         <Setting>
             <Option SelectedID="0">
-                <Item Key="0">Disabled</Item>
-                <Item Key="1">Enabled</Item>
+                <Item Key="0" Translatable="1">Disabled</Item>
+                <Item Key="1" Translatable="1">Enabled</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -203,8 +200,8 @@
         <SubGroup>Core::ProductNews</SubGroup>
         <Setting>
             <Option SelectedID="1">
-                <Item Key="0">Disabled</Item>
-                <Item Key="1">Enabled</Item>
+                <Item Key="0" Translatable="1">Disabled</Item>
+                <Item Key="1" Translatable="1">Enabled</Item>
             </Option>
         </Setting>
     </ConfigItem>
@@ -214,8 +211,8 @@
         <SubGroup>Core::ProductNews</SubGroup>
         <Setting>
             <Option SelectedID="0">
-                <Item Key="0">Disabled</Item>
-                <Item Key="1">Enabled</Item>
+                <Item Key="0" Translatable="1">Disabled</Item>
+                <Item Key="1" Translatable="1">Enabled</Item>
             </Option>
         </Setting>
     </ConfigItem>

--- a/Kernel/Language/de_ProductNews.pm
+++ b/Kernel/Language/de_ProductNews.pm
@@ -1,6 +1,6 @@
 # --
-# Kernel/Language/de_ProductNews.pm - the german translation of ProductNews
-# Copyright (C) 2011-2014 Perl-Services.de, http://perl-services.de/
+# Kernel/Language/de_ProductNews.pm - the German translation of ProductNews
+# Copyright (C) 2011-2016 Perl-Services.de, http://perl-services.de/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -22,27 +22,79 @@ sub Data {
 
     return if ref $Lang ne 'HASH';
 
-    $Lang->{'Add news'}        = 'Neue Nachricht';
-    $Lang->{'News ID'}         = 'Nachricht';
-    $Lang->{'Headline'}        = 'Überschrift';
-    $Lang->{'Teaser'}          = 'Kurztext';
-    $Lang->{'Author'}          = 'Autor';
-    $Lang->{'Add/Change News'} = 'Nachricht hinzufügen/ändern';
-    $Lang->{'News Management'} = 'Nachrichten verwalten';
-    $Lang->{'edit'}            = 'bearbeiten';
-    $Lang->{'delete'}          = 'löschen';
-    $Lang->{'created by'}      = 'erstellt von';
-    $Lang->{'News Item'}       = 'News Beitrag';
-
+    # Kernel/Config/Files/ProductNews.xml
+    $Lang->{'List of JS files to always be loaded for the agent interface.'} =
+        'Liste der JavaScript-Dateien, die immer im Agenten-Interface geladen werden sollen.';
+    $Lang->{'List of JS files to always be loaded for the customer interface.'} =
+        'Liste der JavaScript-Dateien, die immer im Kunden-Interface geladen werden sollen.';
+    $Lang->{'List of CSS files to always be loaded for the agent interface.'} =
+        'Liste der CSS-Dateien, die immer im Agenten-Interface geladen werden sollen.';
+    $Lang->{'List of CSS files to always be loaded for the customer interface.'} =
+        'Liste der CSS-Dateien, die immer im Kunden-Interface geladen werden sollen.';
+    $Lang->{'Frontend module registration for the agent interface.'} =
+        'Frontendmodul-Registration für das Agenten Interface.';
+    $Lang->{'Product News'} = '';
+    $Lang->{'Frontend module registration for the invoice states interface.'} = '';
     $Lang->{'Create and manage news.'} = 'Nachrichten erstellen und verwalten.';
+    $Lang->{'Defines the parameters for the dashboard backend. "Group" is used to restrict access to the plugin (e. g. Group: admin;group1;group2;). "Default" indicates if the plugin is enabled by default or if the user needs to enable it manually.'} = '';
+    $Lang->{'News!'} = '';
+    $Lang->{'Dis-/enables displaying the teaser text of a news entry.'} = '';
+    $Lang->{'Disabled'} = '';
+    $Lang->{'Enabled'} = '';
+    $Lang->{'Dis-/enables displaying the creator of a news entry.'} = '';
+    $Lang->{'Dis-/enables edit-/delete link in dashboard for creator and users of group defined in "ProductNews::DashboardEditDeleteGroup".'} = '';
+    $Lang->{'Defines the group name to which the user must belong to see edit/delete link if not creator.'} = '';
+    $Lang->{'If enabled, everybody can set the message to "invalid" by clicking "mark as read".'} = '';
+    $Lang->{'Configurable header for news widgets.'} = '';
+    $Lang->{'Module to product news in sidebar.'} = '';
+    $Lang->{'Invalidate product news.'} = '';
 
-    $Lang->{'All News'}        = 'Alle Nachrichten';
-    $Lang->{"We are sorry, you do not have permissions to edit this news item."} =
-        'Sie haben keine Berechtigung diesen News-Eintrag zu bearbeiten';
+    # Kernel/Modules/AdminProductNews.pm
+    $Lang->{'We are sorry, you do not have permissions to edit this news item.'} =
+        'Sie haben keine Berechtigung diesen News-Eintrag zu bearbeiten.';
 
-    $Lang->{"Invalidate date"} = 'Nachricht gültig bis';
+    # Kernel/Output/HTML/Templates/Standard/AdminProductNewsForm.tt
+    $Lang->{'News Management'} = 'Nachrichten verwalten';
+    $Lang->{'Actions'} = '';
+    $Lang->{'Go to overview'} = '';
+    $Lang->{'Add/Change News'} = 'Nachricht hinzufügen/ändern';
+    $Lang->{'Headline'} = 'Überschrift';
+    $Lang->{'A headline for the news is required.'} = '';
+    $Lang->{'Teaser'} = 'Kurztext';
+    $Lang->{'Teaser is mandatory.'} = '';
+    $Lang->{'Body'} = '';
+    $Lang->{'A news text is required.'} = '';
+    $Lang->{'Display'} = '';
+    $Lang->{'Select a display.'} = '';
+    $Lang->{'Invalidate date'} = 'Nachricht gültig bis';
     $Lang->{'Open news when user visits dashboard'} = 'Nachricht öffnen wenn Agenten das Dashboard öffnen';
-    $Lang->{'Mark as read'}                         = 'Als gelesen markieren';
+    $Lang->{'Valid'} = '';
+    $Lang->{'Save'} = '';
+    $Lang->{'or'} = '';
+    $Lang->{'Cancel'} = '';
+
+    # Kernel/Output/HTML/Templates/Standard/ProductNewsSnippet.tt
+    $Lang->{'All News'} = 'Alle Nachrichten';
+    $Lang->{'Delete'} = 'Löschen';
+    $Lang->{'News Item'} = 'News Beitrag';
+    $Lang->{'created by'} = 'erstellt von';
+
+    # Kernel/Output/HTML/Templates/Standard/AdminProductNewsList.tt
+    $Lang->{'Add news'} = 'Neue Nachricht';
+    $Lang->{'List'} = '';
+    $Lang->{'News ID'} = 'Nachricht';
+    $Lang->{'Date'} = '';
+    $Lang->{'Author'} = 'Autor';
+    $Lang->{'Action'} = '';
+    $Lang->{'No matches found.'} = '';
+    $Lang->{'edit'} = 'bearbeiten';
+    $Lang->{'delete'} = 'löschen';
+
+    # Kernel/Output/HTML/Templates/Standard/AgentProductNews.tt
+    $Lang->{'Mark as read'} = 'Als gelesen markieren';
+
+    # Kernel/Output/HTML/Templates/Standard/ProductNewsSnippetLogin.tt
+    $Lang->{'Close this dialog'} = '';
 
     return 1;
 }

--- a/Kernel/Language/hu_ProductNews.pm
+++ b/Kernel/Language/hu_ProductNews.pm
@@ -1,0 +1,109 @@
+# --
+# Kernel/Language/hu_ProductNews.pm - the Hungarian translation of ProductNews
+# Copyright (C) 2011-2014 Perl-Services.de, http://perl-services.de/
+# Copyright (C) 2016 Balázs Úr, http://www.otrs-megoldasok.hu/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::hu_ProductNews;
+
+use strict;
+use warnings;
+use utf8;
+
+our $VERSION = 0.02;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation};
+
+    return if ref $Lang ne 'HASH';
+
+    # Kernel/Config/Files/ProductNews.xml
+    $Lang->{'List of JS files to always be loaded for the agent interface.'} =
+        'JS fájlok listája, amelyek mindig betöltődnek az ügyintézői felületnél.';
+    $Lang->{'List of JS files to always be loaded for the customer interface.'} =
+        'JS fájlok listája, amelyek mindig betöltődnek az ügyfélfelületnél.';
+    $Lang->{'List of CSS files to always be loaded for the agent interface.'} =
+        'CSS fájlok listája, amelyek mindig betöltődnek az ügyintézői felületnél.';
+    $Lang->{'List of CSS files to always be loaded for the customer interface.'} =
+        'CSS fájlok listája, amelyek mindig betöltődnek az ügyfélfelületnél.';
+    $Lang->{'Frontend module registration for the agent interface.'} =
+        'Előtétprogram-modul regisztráció az ügyintézői felülethez.';
+    $Lang->{'Product News'} = 'Termékhírek';
+    $Lang->{'Frontend module registration for the invoice states interface.'} = 'Előtétprogram-modul regisztráció a számlaállapotok felülethez.';
+    $Lang->{'Create and manage news.'} = 'Hírek létrehozása és kezelése.';
+    $Lang->{'Defines the parameters for the dashboard backend. "Group" is used to restrict access to the plugin (e. g. Group: admin;group1;group2;). "Default" indicates if the plugin is enabled by default or if the user needs to enable it manually.'} =
+        'Meghatározza a vezérlőpult háttérprogram paramétereit. A „Csoport” használható a hozzáférés korlátozásához a bővítményre (például Csoport: admin;csoport1;csoport2;). Az „Alapértelmezett” jelzi, ha a bővítmény alapértelmezetten engedélyezve van, vagy ha a felhasználónak kézzel kell engedélyeznie azt.';
+    $Lang->{'News!'} = 'Hírek!';
+    $Lang->{'Dis-/enables displaying the teaser text of a news entry.'} =
+        'Engedélyezi vagy letiltja egy hírbejegyzés bevezető szövegének megjelenítését.';
+    $Lang->{'Disabled'} = 'Letiltva';
+    $Lang->{'Enabled'} = 'Engedélyezve';
+    $Lang->{'Dis-/enables displaying the creator of a news entry.'} =
+        'Engedélyezi vagy letiltja egy hírbejegyzés létrehozójának megjelenítését.';
+    $Lang->{'Dis-/enables edit-/delete link in dashboard for creator and users of group defined in "ProductNews::DashboardEditDeleteGroup".'} =
+        'Engedélyezi vagy letiltja a vezérlőpulton a szerkesztés vagy törlés hivatkozást a létrehozónak és a „ProductNews::DashboardEditDeleteGroup” beállításban meghatározott csoport felhasználóinak.';
+    $Lang->{'Defines the group name to which the user must belong to see edit/delete link if not creator.'} =
+        'Meghatározza azt a csoportnevet, amelyhez a felhasználónak tartoznia kell a szerkesztés vagy törlés hivatkozás megtekintéséhez, ha nem létrehozó.';
+    $Lang->{'If enabled, everybody can set the message to "invalid" by clicking "mark as read".'} =
+        'Ha engedélyezve van, akkor mindenki „érvénytelenre” állíthatja az üzenetet a „megjelölés olvasottként” hivatkozásra kattintva.';
+    $Lang->{'Configurable header for news widgets.'} = 'Beállítható fejléc a hírek felületi elemeknél.';
+    $Lang->{'Module to product news in sidebar.'} = 'Egy modul az oldalsávon lévő termékhírekhez.';
+    $Lang->{'Invalidate product news.'} = 'Termékhírek érvénytelenítése.';
+
+    # Kernel/Modules/AdminProductNews.pm
+    $Lang->{'We are sorry, you do not have permissions to edit this news item.'} =
+        'Sajnáljuk, de nincs jogosultsága a hírek elem szerkesztéséhez.';
+
+    # Kernel/Output/HTML/Templates/Standard/AdminProductNewsForm.tt
+    $Lang->{'News Management'} = 'Hírek kezelése';
+    $Lang->{'Actions'} = 'Műveletek';
+    $Lang->{'Go to overview'} = 'Ugrás az áttekintőhöz';
+    $Lang->{'Add/Change News'} = 'Hírek hozzáadása vagy megváltoztatása';
+    $Lang->{'Headline'} = 'Hírösszefoglaló';
+    $Lang->{'A headline for the news is required.'} = 'A hírösszefoglaló kötelező a hírekhez.';
+    $Lang->{'Teaser'} = 'Bevezető';
+    $Lang->{'Teaser is mandatory.'} = 'A bevezető kötelező.';
+    $Lang->{'Body'} = 'Törzs';
+    $Lang->{'A news text is required.'} = 'A hír törzse kötelező.';
+    $Lang->{'Display'} = 'Megjelenítő';
+    $Lang->{'Select a display.'} = 'Válasszon egy megjelenítőt.';
+    $Lang->{'Invalidate date'} = 'Dátum érvénytelenítése';
+    $Lang->{'Open news when user visits dashboard'} = 'Hírek megnyitása, amikor a felhasználó megnézi a vezérlőpultot';
+    $Lang->{'Valid'} = 'Érvényes';
+    $Lang->{'Save'} = 'Mentés';
+    $Lang->{'or'} = 'vagy';
+    $Lang->{'Cancel'} = 'Mégse';
+
+    # Kernel/Output/HTML/Templates/Standard/ProductNewsSnippet.tt
+    $Lang->{'All News'} = 'Összes hír';
+    $Lang->{'Delete'} = 'Törlés';
+    $Lang->{'News Item'} = 'Hírek elem';
+    $Lang->{'created by'} = 'létrehozta';
+
+    # Kernel/Output/HTML/Templates/Standard/AdminProductNewsList.tt
+    $Lang->{'Add news'} = 'Hírek hozzáadása';
+    $Lang->{'List'} = 'Lista';
+    $Lang->{'News ID'} = 'Hírazonosító';
+    $Lang->{'Date'} = 'Dátum';
+    $Lang->{'Author'} = 'Szerző';
+    $Lang->{'Action'} = 'Művelet';
+    $Lang->{'No matches found.'} = 'Nincs találat.';
+    $Lang->{'edit'} = 'szerkesztés';
+    $Lang->{'delete'} = 'törlés';
+
+    # Kernel/Output/HTML/Templates/Standard/AgentProductNews.tt
+    $Lang->{'Mark as read'} = 'Megjelölés olvasottként';
+
+    # Kernel/Output/HTML/Templates/Standard/ProductNewsSnippetLogin.tt
+    $Lang->{'Close this dialog'} = 'Párbeszédablak bezárása';
+
+    return 1;
+}
+
+1;

--- a/Kernel/Language/zh_CN_ProductNews.pm
+++ b/Kernel/Language/zh_CN_ProductNews.pm
@@ -1,5 +1,5 @@
 # --
-# Kernel/Language/de_ProductNews.pm - the german translation of ProductNews
+# Kernel/Language/zh_CN_ProductNews.pm - the Chinese translation of ProductNews
 # Copyright (C) 2011-2014 Perl-Services.de, http://perl-services.de/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -22,27 +22,79 @@ sub Data {
 
     return if ref $Lang ne 'HASH';
 
-    $Lang->{'Add news'}        = '增加消息';
-    $Lang->{'News ID'}         = '消息编号';
-    $Lang->{'Headline'}        = '标题';
-    $Lang->{'Teaser'}          = '测试者';
-    $Lang->{'Author'}          = '作者';
-    $Lang->{'Add/Change News'} = '增加或更改消息';
-    $Lang->{'News Management'} = '消息管理';
-    $Lang->{'edit'}            = '编辑';
-    $Lang->{'delete'}          = '删除';
-    $Lang->{'created by'}      = '创建者';
-    $Lang->{'News Item'}       = '新消息';
-
+    # Kernel/Config/Files/ProductNews.xml
+    $Lang->{'List of JS files to always be loaded for the agent interface.'} =
+        '服务人员界面始终载入的JS文件列表。';
+    $Lang->{'List of JS files to always be loaded for the customer interface.'} =
+        '客户界面始终载入的JS文件列表。';
+    $Lang->{'List of CSS files to always be loaded for the agent interface.'} =
+        '服务人员界面始终载入的CSS文件列表。';
+    $Lang->{'List of CSS files to always be loaded for the customer interface.'} =
+        '客户界面始终载入的CSS文件列表。';
+    $Lang->{'Frontend module registration for the agent interface.'} =
+        '服务人员界面的前端模块注册。';
+    $Lang->{'Product News'} = '';
+    $Lang->{'Frontend module registration for the invoice states interface.'} = '';
     $Lang->{'Create and manage news.'} = '创建和管理消息.';
+    $Lang->{'Defines the parameters for the dashboard backend. "Group" is used to restrict access to the plugin (e. g. Group: admin;group1;group2;). "Default" indicates if the plugin is enabled by default or if the user needs to enable it manually.'} = '';
+    $Lang->{'News!'} = '';
+    $Lang->{'Dis-/enables displaying the teaser text of a news entry.'} = '';
+    $Lang->{'Disabled'} = '';
+    $Lang->{'Enabled'} = '';
+    $Lang->{'Dis-/enables displaying the creator of a news entry.'} = '';
+    $Lang->{'Dis-/enables edit-/delete link in dashboard for creator and users of group defined in "ProductNews::DashboardEditDeleteGroup".'} = '';
+    $Lang->{'Defines the group name to which the user must belong to see edit/delete link if not creator.'} = '';
+    $Lang->{'If enabled, everybody can set the message to "invalid" by clicking "mark as read".'} = '';
+    $Lang->{'Configurable header for news widgets.'} = '';
+    $Lang->{'Module to product news in sidebar.'} = '';
+    $Lang->{'Invalidate product news.'} = '';
 
-    $Lang->{'All News'}        = '所有消息';
-    $Lang->{"We are sorry, you do not have permissions to edit this news item."} =
+    # Kernel/Modules/AdminProductNews.pm
+    $Lang->{'We are sorry, you do not have permissions to edit this news item.'} =
         '抱歉, 你没有编辑该消息的权限.';
 
-    $Lang->{"Invalidate date"} = '截止日期';
+    # Kernel/Output/HTML/Templates/Standard/AdminProductNewsForm.tt
+    $Lang->{'News Management'} = '消息管理';
+    $Lang->{'Actions'} = '';
+    $Lang->{'Go to overview'} = '';
+    $Lang->{'Add/Change News'} = '增加或更改消息';
+    $Lang->{'Headline'} = '标题';
+    $Lang->{'A headline for the news is required.'} = '';
+    $Lang->{'Teaser'} = '测试者';
+    $Lang->{'Teaser is mandatory.'} = '';
+    $Lang->{'Body'} = '内容';
+    $Lang->{'A news text is required.'} = '';
+    $Lang->{'Display'} = '';
+    $Lang->{'Select a display.'} = '';
+    $Lang->{'Invalidate date'} = '截止日期';
     $Lang->{'Open news when user visits dashboard'} = '当用户访问信息中心时打开该消息';
-    $Lang->{'Mark as read'}                         = '标记为已读';
+    $Lang->{'Valid'} = '有效';
+    $Lang->{'Save'} = '保存';
+    $Lang->{'or'} = '或';
+    $Lang->{'Cancel'} = '取消';
+
+    # Kernel/Output/HTML/Templates/Standard/ProductNewsSnippet.tt
+    $Lang->{'All News'} = '所有消息';
+    $Lang->{'Delete'} = '删除';
+    $Lang->{'News Item'} = '新消息';
+    $Lang->{'created by'} = '创建者';
+
+    # Kernel/Output/HTML/Templates/Standard/AdminProductNewsList.tt
+    $Lang->{'Add news'} = '增加消息';
+    $Lang->{'List'} = '列表';
+    $Lang->{'News ID'} = '消息编号';
+    $Lang->{'Date'} = '日期';
+    $Lang->{'Author'} = '作者';
+    $Lang->{'Action'} = '操作';
+    $Lang->{'No matches found.'} = '没有找到相匹配的.';
+    $Lang->{'edit'} = '编辑';
+    $Lang->{'delete'} = '删除';
+
+    # Kernel/Output/HTML/Templates/Standard/AgentProductNews.tt
+    $Lang->{'Mark as read'} = '标记为已读';
+
+    # Kernel/Output/HTML/Templates/Standard/ProductNewsSnippetLogin.tt
+    $Lang->{'Close this dialog'} = '关闭该对话框';
 
     return 1;
 }

--- a/Kernel/Output/HTML/Templates/Standard/ProductNewsSnippetLogin.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ProductNewsSnippetLogin.tt
@@ -64,7 +64,7 @@
 [% RenderBlockStart("NewsContent") %]
 <div id="ProductNewsXExtended_[% Data.NewsID | html %]" class="Hidden">
     <div class="Header">
-        <a class="Close" title="Close this dialog" href="#">
+        <a class="Close" title=[% Translate("Close this dialog") | html %] href="#">
             <i class="fa fa-times"></i>
         </a>
         <h1>[% Translate(Data.Headline, "100") | html %]</h1>

--- a/ProductNews.sopm
+++ b/ProductNews.sopm
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <otrs_package version="1.1">
     <Name>ProductNews</Name>
-    <Version>5.0.4</Version>
+    <Version>5.0.5</Version>
     <Vendor>Perl-Services.de</Vendor>
-    <URL>http://perl-services.de.de/</URL>
+    <URL>http://perl-services.de/</URL>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
+    <ChangeLog Version="5.0.5" Date="2016-04-24 17:20:44">Added Hungarian translation, thanks to Balázs Úr.</ChangeLog>
     <Description Lang="en">A module that adds own product news to OTRS.</Description>
     <Description Lang="de">Ein Modul, mit dem eigene Produktneuigkeiten in OTRS gepflegt werden können.</Description>
+    <Description Lang="hu">Egy modul, amely saját termékhíreket ad az OTRS-hez.</Description>
     <Framework>5.0.x</Framework>
     <Filelist>
         <File Permission="644" Location="Kernel/Config/Files/ProductNews.xml" />
         <File Permission="644" Location="Kernel/Language/de_ProductNews.pm" />
+        <File Permission="644" Location="Kernel/Language/hu_ProductNews.pm" />
         <File Permission="644" Location="Kernel/Language/zh_CN_ProductNews.pm" />
         <File Permission="644" Location="Kernel/Modules/AdminProductNews.pm" />
         <File Permission="644" Location="Kernel/Modules/AgentProductNewsMarkRead.pm" />
@@ -26,6 +29,7 @@
         <File Permission="644" Location="Kernel/System/ProductNews.pm" />
         <File Permission="644" Location="Kernel/System/Console/Command/Maint/ProductNews/Invalidate.pm" />
         <File Permission="644" Location="doc/en/ProductNews.pod" />
+        <File Permission="644" Location="doc/hu/ProductNews.pod" />
         <File Permission="644" Location="var/httpd/htdocs/js/Core.UI.Dialog.DynamicContentDialog.js"/>
         <File Permission="644" Location="var/httpd/htdocs/skins/Agent/default/css/Core.ProductNewsX.css"/>
         <File Permission="644" Location="var/httpd/htdocs/skins/Customer/default/css/Core.ProductNewsX.css"/>

--- a/doc/en/ProductNews.pod
+++ b/doc/en/ProductNews.pod
@@ -33,6 +33,10 @@ Never Min, znuny (L<http://znuny.cn>)
 
  * Chinese translation
 
+Balázs Úr, OTRS-megoldások (L<http://www.otrs-megoldasok.hu>)
+
+ * Hungarian translation
+
 =head1 AUTHOR AND LICENSE
 
 Renee Baecker, L<http://perl-services.de>

--- a/doc/hu/ProductNews.pod
+++ b/doc/hu/ProductNews.pod
@@ -1,0 +1,57 @@
+=encoding utf-8
+
+=head1 NÉV
+
+ProductNews - Hírek megjelenítése a vezérlőpulton a termékkel kapcsolatban
+
+=head1 LEÍRÁS
+
+Ha hírei vannak a termékével kapcsolatban, vagy bármilyen egyéb üzenete lenne, 
+amelyről az OTRS rendszer összes ügyintézőjének tudnia kell, akkor ennek 
+kezeléséhez használhatja a termékhíreket.
+
+Ezzel a kiegészítővel egy új vezérlőpult felületi elem jön létre, és az 
+adminisztrátorok híreket adhatnak hozzá.
+
+A 4.0.4-es verzióhoz hasonlóan az összes felhasználó létrehozhat híreket, és az 
+adminisztrátor, valamint a hírek szerzője szerkesztheti azokat. Mostantól 
+lehetőség van a hírek megtekintésére más nézeteken is: AgentTicketZoom, 
+AgentTicketPhone, AgentTicketEmail.
+
+=head1 TÁROLÓ ÉS HIBAKÖVETŐ
+
+A kódtároló és a hibakövető a L<http://github.com/reneeb/otrs-ProductNews> 
+címen érhető el.
+
+=head1 HOZZÁJÁRULÓK
+
+Torsten Thau, c.a.p.e IT (L<http://cape-it.de>)
+
+ * Felkészítés az OTRS 3.3-hoz
+ * Sorközi szerkesztés
+
+Oberender Frank, c.a.p.e IT (L<http://cape-it.de>)
+
+ * Láthatóság az ügyfél előtétprogramján és a bejelentkező képernyőkön
+
+Never Min, znuny (L<http://znuny.cn>)
+
+ * Kínai fordítás
+
+Úr Balázs, OTRS-megoldások (L<http://www.otrs-megoldasok.hu>)
+
+ * Magyar fordítás
+
+=head1 SZERZŐ ÉS LICENC
+
+Renée Bäcker, L<http://perl-services.de>
+
+Ez a szoftver MINDENFÉLE GARANCIA NÉLKÜL érkezik. A részletekért és a 
+licencinformációkért (AGPL) nézze meg a mellékelt COPYING fájlt. Ha nem kapta 
+meg a fájlt, akkor olvassa el a L<http://www.gnu.org/licenses/agpl.txt> címen.
+
+=head1 MAGYAR FORDÍTÁS
+
+A magyar fordítást az OTRS-megoldások csapata készítette.
+Copyright (C) 2016 Úr Balázs, L<http://otrs-megoldasok.hu>
+


### PR DESCRIPTION
Hi @reneeb 

Here is the Hungarian translation for ProductNews. I made some small fixes, as you can see below. The German and Chinese texts was copy-pasted from OTRS language files. The German translation file is incomplete, you can fill it out.

I made an OTRS package and installed it on my test system. On the dashboard in the setting there are two Product news entry (both are checked), but no Product news widget is displayed. Can you check it?

In the <a href="https://github.com/reneeb/otrs-ProductNews/blob/master/Kernel/Config/Files/ProductNews.xml#L83">Kernel/Config/Files/ProductNews.xml</a> there is a strange description: "Frontend module registration for the invoice states interface."
What is "invoice states interface"? Maybe this was copy-pasted from somewhere?
