### PR TITLE
Modernized input fields

### DIFF
--- a/Kernel/Modules/AdminProductNews.pm
+++ b/Kernel/Modules/AdminProductNews.pm
@@ -297,11 +297,12 @@ sub _MaskNewsForm {
             'Dashboard' => 'Dashboard',
             map{ $_ => $_ }@Templates,
         },
-        Name       => 'Display',
-        SelectedID => $Param{Display},
-        Class      => 'ValidateRequired ' . ( $Param{DisplayInvalid} || '' ),
-        Multiple   => 1,
-        Size       => 5,
+        Name        => 'Display',
+        SelectedID  => $Param{Display},
+        Class       => 'ValidateRequired Modernize ' . ( $Param{DisplayInvalid} || '' ),
+        Multiple    => 1,
+        Size        => 5,
+        Translation => 0,
     );
 
     my $ValidID = $ValidObject->ValidLookup( Valid => 'valid' );
@@ -311,6 +312,7 @@ sub _MaskNewsForm {
         Name       => 'ValidID',
         Size       => 1,
         SelectedID => $Param{ValidID} || $ValidID,
+        Class      => 'Modernize',
         HTMLQuote  => 1,
     );
 


### PR DESCRIPTION
Hi @reneeb 
I promise, this is my last PR :)
I changed the input fields to modernized ones according to other input fields in OTRS.
I also disabled the translation for displays, as custom display names can be added in SysConfig. If some adds a new screen, which name is matching to any translation entries in the OTRS, the display name will be translated. This causes a strange list containing mixed translated and untranslated entries.
